### PR TITLE
Initial Windows support + path fixes

### DIFF
--- a/steeb/preference.py
+++ b/steeb/preference.py
@@ -1,4 +1,4 @@
-import getpass
+import os.path
 
-download_dir = "/home/" + getpass.getuser() + "/Music/Downloads/" 
+download_dir = os.path.join(os.path.expanduser("~"), os.path.join("Downloads", "Music"))
 force_hq = False #TODO: implement

--- a/steeb/steeb.pyw
+++ b/steeb/steeb.pyw
@@ -109,7 +109,9 @@ def download(fileurl, file_name):
     downwin['progressbar'].value = 0 
 
     u = urllib2.urlopen(fileurl)
-    f = open(pref.download_dir + file_name, 'wb')
+    if not os.path.exists(pref.download_dir):
+        os.makedirs(pref.download_dir)
+    f = open(os.path.join(pref.download_dir, file_name + ".mp3"), 'wb')
     meta = u.info()
     file_size = int(meta.getheaders("Content-Length")[0])
 


### PR DESCRIPTION
Default download directory will now translate to C:\Users<your name here>\Downloads\Music on Windows.

Furthermore, if the download directory does not exist, make it first. Lastly, join the download directory, file name and file extension in a platform-agnostic fashion.
